### PR TITLE
Implement SK_API_VERSION 10 for OpenSSH 9.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ option(BUILD_TESTS "Build tests" ON)
 
 # Configurable OpenSSH security key API version
 set(SK_API_VERSION 7 CACHE STRING "OpenSSH security key API version to target")
-list(APPEND VALID_SK_API_VERSIONS 5 7 9)
+list(APPEND VALID_SK_API_VERSIONS 5 7 9 10)
 if (NOT SK_API_VERSION IN_LIST VALID_SK_API_VERSIONS)
     message(FATAL_ERROR "Unrecognized OpenSSH security key API version \"${SK_API_VERSION}\"")
 endif()
@@ -183,7 +183,11 @@ elseif ("${SK_API_VERSION}" EQUAL 7)
     )
 elseif ("${SK_API_VERSION}" EQUAL 9)
     set(CPACK_DEBIAN_REAL_DEB_GROUP_PACKAGE_DEPENDS
-        "${CPACK_DEBIAN_REAL_DEB_GROUP_PACKAGE_DEPENDS}, openssh-client (>= 1:8.9)"
+        "${CPACK_DEBIAN_REAL_DEB_GROUP_PACKAGE_DEPENDS}, openssh-client (>= 1:8.9), openssh-client (<< 1:9.1)"
+    )
+elseif ("${SK_API_VERSION}" EQUAL 10)
+    set(CPACK_DEBIAN_REAL_DEB_GROUP_PACKAGE_DEPENDS
+        "${CPACK_DEBIAN_REAL_DEB_GROUP_PACKAGE_DEPENDS}, openssh-client (>= 1:9.1)"
     )
 else()
     message(FATAL_ERROR "Unknown SK_API_VERSION ${SK_API_VERSION} when configuring deb package")

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ You may set the following options when you invoke `cmake`:
     * `5`: OpenSSH 8.3
     * `7`: OpenSSH 8.4 (default)
     * `9`: OpenSSH 8.9
+    * `10`: OpenSSH 9.1
 
 ## Use
 

--- a/repo/build-repo-packages
+++ b/repo/build-repo-packages
@@ -11,6 +11,7 @@ sk_api_versions=(
     5
     7
     9
+    10
 )
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"

--- a/src/common/3p-include/sk-api-v10.h
+++ b/src/common/3p-include/sk-api-v10.h
@@ -1,0 +1,103 @@
+/* $OpenBSD: sk-api.h,v 1.15 2022/07/20 03:29:14 djm Exp $ */
+/*
+ * Copyright (c) 2019 Google LLC
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef _SK_API_H
+#define _SK_API_H 1
+
+#include <stddef.h>
+#ifdef HAVE_STDINT_H
+#include <stdint.h>
+#endif
+
+/* Flags */
+#define SSH_SK_USER_PRESENCE_REQD	0x01
+#define SSH_SK_USER_VERIFICATION_REQD	0x04
+#define SSH_SK_FORCE_OPERATION		0x10
+#define SSH_SK_RESIDENT_KEY		0x20
+
+/* Algs */
+#define SSH_SK_ECDSA			0x00
+#define SSH_SK_ED25519			0x01
+
+/* Error codes */
+#define SSH_SK_ERR_GENERAL		-1
+#define SSH_SK_ERR_UNSUPPORTED		-2
+#define SSH_SK_ERR_PIN_REQUIRED		-3
+#define SSH_SK_ERR_DEVICE_NOT_FOUND	-4
+#define SSH_SK_ERR_CREDENTIAL_EXISTS	-5
+
+struct sk_enroll_response {
+	uint8_t flags;
+	uint8_t *public_key;
+	size_t public_key_len;
+	uint8_t *key_handle;
+	size_t key_handle_len;
+	uint8_t *signature;
+	size_t signature_len;
+	uint8_t *attestation_cert;
+	size_t attestation_cert_len;
+	uint8_t *authdata;
+	size_t authdata_len;
+};
+
+struct sk_sign_response {
+	uint8_t flags;
+	uint32_t counter;
+	uint8_t *sig_r;
+	size_t sig_r_len;
+	uint8_t *sig_s;
+	size_t sig_s_len;
+};
+
+struct sk_resident_key {
+	uint32_t alg;
+	size_t slot;
+	char *application;
+	struct sk_enroll_response key;
+	uint8_t flags;
+	uint8_t *user_id;
+	size_t user_id_len;
+};
+
+struct sk_option {
+	char *name;
+	char *value;
+	uint8_t required;
+};
+
+#define SSH_SK_VERSION_MAJOR		0x000a0000 /* current API version */
+#define SSH_SK_VERSION_MAJOR_MASK	0xffff0000
+
+/* Return the version of the middleware API */
+uint32_t sk_api_version(void);
+
+/* Enroll a U2F key (private key generation) */
+int sk_enroll(uint32_t alg, const uint8_t *challenge, size_t challenge_len,
+    const char *application, uint8_t flags, const char *pin,
+    struct sk_option **options, struct sk_enroll_response **enroll_response);
+
+/* Sign a challenge */
+int sk_sign(uint32_t alg, const uint8_t *data, size_t data_len,
+    const char *application, const uint8_t *key_handle, size_t key_handle_len,
+    uint8_t flags, const char *pin, struct sk_option **options,
+    struct sk_sign_response **sign_response);
+
+/* Enumerate all resident keys */
+int sk_load_resident_keys(const char *pin, struct sk_option **options,
+    struct sk_resident_key ***rks, size_t *nrks);
+
+#endif /* _SK_API_H */


### PR DESCRIPTION
I was unsure of whether to call it version `10` or version `a`, but went with `10`. I will happily change it if you prefer `a`.
